### PR TITLE
Add an option for --single-quote, but strongly prefer double quote in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Options:
                               source on standard input).
   -S, --skip-string-normalization
                               Don't normalize string quotes or prefixes.
+  --single-quote              Use single quotes instead of double quotes in
+                              strings except for triple-quoted strings.
   --check                     Don't write the files back, just return the
                               status.  Return code 0 means nothing would
                               change.  Return code 1 means some files would be
@@ -360,6 +362,9 @@ empty string in double quotes (`""`) is impossible to confuse with
 a one double-quote regardless of fonts and syntax highlighting used.
 On top of this, double quotes for strings are consistent with C which
 Python interacts a lot with.
+
+> While we strongly recommend double quotes, we also provide a
+> `--single-quote` option if you prefer.
 
 On certain keyboard layouts like US English, typing single quotes is
 a bit easier than double quotes.  The latter requires use of the Shift


### PR DESCRIPTION
Simply adds a `--single-quote` option, though it appears that upstream is not keen in adding this complexity to trunk. So out of respect to ambv and the fundamental intent of the project, we won't be opening a PR to the core repo (as it will likely just result in useless bike shedding).

However, if Zapier decides to make use of black, we'll likely maintain this internal fork and will regularly rebase it. If upstream ever decides to entertain single quotes, certainly happy to provide this code to the community!

Mostly provided here as an ongoing reference point.